### PR TITLE
fix for k0s install bypass

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,11 +17,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
-    - name: Setup MCC gitub repo private access
-      run: git config --global url."https://${{ secrets.GH_MCC_USERNAME }}:${{ secrets.GH_MCC_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        go-version: '>=1.21'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,29 +20,21 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup MCC gitub repo private access
-        run: git config --global url."https://${{ secrets.GH_MCC_USERNAME }}:${{ secrets.GH_MCC_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Unshallow
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-          cache: true
-      -
-        name: Import GPG key
+          go-version: '1.21'
+      - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
         run: git config --global url."https://${{ secrets.GH_MCC_USERNAME }}:${{ secrets.GH_MCC_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4.0.1
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-          cache: true
+          go-version: '1.21'
       - run: go mod download
       - run: go build -v .
       - name: Run linters
@@ -48,10 +48,10 @@ jobs:
         run: git config --global url."https://${{ secrets.GH_MCC_USERNAME }}:${{ secrets.GH_MCC_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4.0.1
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-          cache: true
+          go-version: '1.21'
       - run: go generate ./...
       - name: git diff
         run: |
@@ -71,17 +71,15 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.4.*'
+          - '1.6.*'
+          - '1.5.*'
     steps:
-      - name: Setup MCC gitub repo private access
-        run: git config --global url."https://${{ secrets.GH_MCC_USERNAME }}:${{ secrets.GH_MCC_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4.0.1
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-          cache: true
-      - uses: hashicorp/setup-terraform@v2.0.3
+          go-version: '1.21'
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false

--- a/.github/workflows/tfsec.yaml
+++ b/.github/workflows/tfsec.yaml
@@ -14,6 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,9 +8,7 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v4
       - name: 'Setup Terraform'
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: 1.0.3
+        uses: hashicorp/setup-terraform@v3
       - name: Terraform Init
         id: init
         run: terraform init

--- a/internal/provider/k0s_config_resource.go
+++ b/internal/provider/k0s_config_resource.go
@@ -99,22 +99,19 @@ func (r *K0sctlConfigResource) Create(ctx context.Context, req resource.CreateRe
 		RestoreFrom:           kcsm.RestoreFrom.ValueString(),
 	}
 
+	kcsm.KubeYaml = types.StringNull()
+	kcsm.KubeHost = types.StringNull()
+	kcsm.CaCert = types.StringNull()
+	kcsm.PrivateKey = types.StringNull()
+	kcsm.ClientCert = types.StringNull()
+	kcsm.Id = kcsm.Metadata.Name
+
 	if kcsm.SkipCreate.ValueBool() {
 		resp.Diagnostics.AddWarning("skipping create", "Skipping the k0sctl create because of configuration flag.")
+		resp.Diagnostics.Append(resp.State.Set(ctx, kcsm)...)
 	} else if r.testingMode {
 		resp.Diagnostics.AddWarning("testing mode warning", "k0sctl config resource handler is in testing mode, no installation will be run.")
-
-		kcsm.KubeYaml = types.StringNull()
-		kcsm.KubeHost = types.StringNull()
-		kcsm.CaCert = types.StringNull()
-		kcsm.PrivateKey = types.StringNull()
-		kcsm.ClientCert = types.StringNull()
-
-		kcsm.Id = kcsm.Metadata.Name
-
-		if diags := resp.State.Set(ctx, kcsm); diags != nil {
-			resp.Diagnostics.Append(diags...)
-		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, kcsm)...)
 	} else if err := aa.Run(); err != nil {
 		resp.Diagnostics.Append(diag.NewErrorDiagnostic("error running k0sctl apply", err.Error()))
 	} else {


### PR DESCRIPTION
# Description

Fix broke SkipCreate: skip create currently broken because some required state vars are not populated

ALSO: 
- GH action fixes
  - update all actions, and standardize on softer version constraints
  - standardize format for yaml lists
  - all setup-go use golang 1.21
