### PR TITLE
More config options

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -64,7 +64,10 @@ Required:
 Optional:
 
 - `hooks` (Block List) Hook configuration for the host (see [below for nested schema](#nestedblock--spec--host--hooks))
+- `hostname` (String) Hostname override for the host
 - `install_flags` (List of String) String install flags passed to k0s (e.g. '--taints=mytaint')
+- `no_taints` (Boolean) Do not apply taints to the host, used in conjunction with the controller+worker role
+- `private_address` (String) Private address override for the host
 - `ssh` (Block List) SSH configuration for the host (see [below for nested schema](#nestedblock--spec--host--ssh))
 - `winrm` (Block List) WinRM configuration for the host (see [below for nested schema](#nestedblock--spec--host--winrm))
 
@@ -96,7 +99,22 @@ Required:
 
 Optional:
 
+- `bastion` (Block List) SSH bastion configuration for the host (see [below for nested schema](#nestedblock--spec--host--ssh--bastion))
 - `port` (Number) SSH Port
+
+<a id="nestedblock--spec--host--ssh--bastion"></a>
+### Nested Schema for `spec.host.ssh.bastion`
+
+Required:
+
+- `address` (String) bastion endpoint
+- `key_path` (String) bastion endpoint
+- `user` (String) bastion endpoint
+
+Optional:
+
+- `port` (Number) bastion Port
+
 
 
 <a id="nestedblock--spec--host--winrm"></a>

--- a/internal/provider/schema.go
+++ b/internal/provider/schema.go
@@ -176,6 +176,18 @@ func k0sctl_v1beta1_schema() schema.Schema {
 									Optional:            true,
 									ElementType:         types.StringType,
 								},
+								"hostname": schema.StringAttribute{
+									MarkdownDescription: "Hostname override for the host",
+									Optional:            true,
+								},
+								"private_address": schema.StringAttribute{
+									MarkdownDescription: "Private address override for the host",
+									Optional:            true,
+								},
+								"no_taints": schema.BoolAttribute{
+									MarkdownDescription: "Do not apply taints to the host, used in conjuction with the controller+worker role",
+									Optional:            true,
+								},
 							},
 
 							Blocks: map[string]schema.Block{
@@ -398,8 +410,11 @@ func (ksm *k0sctlSchemaModel) Cluster(ctx context.Context) (k0sctl_v1beta1.Clust
 
 	for _, sh := range ksm.Spec.Hosts {
 		h := k0sctl_v1beta1_cluster.Host{
-			Role:  sh.Role.ValueString(),
-			Hooks: k0sctl_v1beta1_cluster.Hooks{},
+			Role:             sh.Role.ValueString(),
+			Hooks:            k0sctl_v1beta1_cluster.Hooks{},
+			PrivateAddress:   sh.PrivateAddress.ValueString(),
+			HostnameOverride: sh.Hostname.ValueString(),
+			NoTaints:         sh.NoTaints.ValueBool(),
 		}
 
 		if len(sh.InstallFlags) > 0 {
@@ -577,11 +592,14 @@ type k0sctlSchemaModelSpecK0s struct {
 }
 
 type k0sctlSchemaModelSpecHost struct {
-	Role         types.String                     `tfsdk:"role"`
-	InstallFlags []types.String                   `tfsdk:"install_flags"`
-	Hooks        []k0sctlSchemaModelSpecHostHooks `tfsdk:"hooks"`
-	SSH          []k0sctlSchemaModelSpecHostSSH   `tfsdk:"ssh"`
-	WinRM        []k0sctlSchemaModelSpecHostWinrm `tfsdk:"winrm"`
+	Role           types.String                     `tfsdk:"role"`
+	InstallFlags   []types.String                   `tfsdk:"install_flags"`
+	Hooks          []k0sctlSchemaModelSpecHostHooks `tfsdk:"hooks"`
+	SSH            []k0sctlSchemaModelSpecHostSSH   `tfsdk:"ssh"`
+	WinRM          []k0sctlSchemaModelSpecHostWinrm `tfsdk:"winrm"`
+	PrivateAddress types.String                     `tfsdk:"private_address"`
+	Hostname       types.String                     `tfsdk:"hostname"`
+	NoTaints       types.Bool                       `tfsdk:"no_taints"`
 }
 type k0sctlSchemaModelSpecHostHooks struct {
 	Apply []k0sctlSchemaModelSpecHostHookAction `tfsdk:"apply"`

--- a/internal/provider/schema.go
+++ b/internal/provider/schema.go
@@ -185,7 +185,7 @@ func k0sctl_v1beta1_schema() schema.Schema {
 									Optional:            true,
 								},
 								"no_taints": schema.BoolAttribute{
-									MarkdownDescription: "Do not apply taints to the host, used in conjuction with the controller+worker role",
+									MarkdownDescription: "Do not apply taints to the host, used in conjunction with the controller+worker role",
 									Optional:            true,
 								},
 							},


### PR DESCRIPTION
# Description

This adds config options support for 
- bastion on linux hosts(ssh)
- private_address override on node
- hostname override on node
- no_taints flag to disable tainting of controller+worker nodes(this could already be achieved with an install flag, but direct option seems cleaner and better conforms to the yaml config for k0sctl

## Issue
This addresses  #7 

