### PR TITLE
PRODENG-2549 Add new input argument key_content for resource k0sctl_config

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -94,12 +94,13 @@ Optional:
 Required:
 
 - `address` (String) SSH endpoint
-- `key_path` (String) SSH endpoint
 - `user` (String) SSH endpoint
 
 Optional:
 
 - `bastion` (Block List) SSH bastion configuration for the host (see [below for nested schema](#nestedblock--spec--host--ssh--bastion))
+- `key_content` (String) Content of the ssh key
+- `key_path` (String) SSH endpoint
 - `port` (Number) SSH Port
 
 <a id="nestedblock--spec--host--ssh--bastion"></a>
@@ -108,11 +109,12 @@ Optional:
 Required:
 
 - `address` (String) bastion endpoint
-- `key_path` (String) bastion endpoint
 - `user` (String) bastion endpoint
 
 Optional:
 
+- `key_content` (String) Content of the ssh key for the bastion host
+- `key_path` (String) bastion endpoint
 - `port` (Number) bastion Port
 
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/k0sproject/rig v0.18.4
 	github.com/k0sproject/version v0.6.0
 	github.com/sirupsen/logrus v1.9.3
+	golang.org/x/crypto v0.24.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -110,7 +111,6 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.14.4 // indirect
-	golang.org/x/crypto v0.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.26.0 // indirect


### PR DESCRIPTION
# Description

       - Introduced a new optional arg key_content to provide the raw content of the ssh keys for hosts and bastion hosts
       - Validated the key_content and key_path so that the user must provide either one of them

## Issue

https://mirantis.jira.com/browse/PRODENG-2549