### PR TITLE
PRODENG-2674 Passing the terraform provider context to register loggers

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -56,7 +56,7 @@ func (p *K0sctlProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	resp.ResourceData = &data
 	resp.DataSourceData = &data
 
-	AllLoggingToTFLog()
+	AllLoggingToTFLog(ctx)
 }
 
 func (p *K0sctlProvider) Resources(ctx context.Context) []func() resource.Resource {


### PR DESCRIPTION
 - For tflog to work, the same context need to be propagated to all the logger events.
 - So, injecting the terraform provider context when registering logrus and rig logger hooks

